### PR TITLE
Add dedicated family import page

### DIFF
--- a/app/Filament/Pages/ImportFamilies.php
+++ b/app/Filament/Pages/ImportFamilies.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use Filament\Forms\Form;
+use Filament\Pages\Page;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Components\FileUpload;
+use Filament\Notifications\Notification;
+use Illuminate\Http\UploadedFile;
+use Maatwebsite\Excel\Facades\Excel;
+use App\Imports\FamilyImport;
+
+class ImportFamilies extends Page
+{
+    use InteractsWithForms;
+
+    protected static ?string $navigationIcon = 'heroicon-o-arrow-up-tray';
+
+    protected static ?string $navigationGroup = 'Data Warga';
+
+    protected static ?string $title = 'Import Data Keluarga';
+
+    protected static ?string $navigationLabel = 'Import Keluarga';
+
+    protected static ?int $navigationSort = 2;
+
+    protected static string $view = 'filament.pages.import-families';
+
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                FileUpload::make('file')
+                    ->label('File Excel')
+                    ->required()
+                    ->helperText('Gunakan template import yang telah disediakan.')
+                    ->acceptedFileTypes(['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet','application/vnd.ms-excel']),
+            ])
+            ->statePath('data');
+    }
+
+    public function import(): void
+    {
+        $file = $this->data['file'] ?? null;
+
+        if ($file instanceof UploadedFile) {
+            try {
+                Excel::import(new FamilyImport, $file);
+
+                $this->form->fill();
+
+                Notification::make()
+                    ->title('Import Berhasil')
+                    ->success()
+                    ->send();
+            } catch (\Throwable $e) {
+                Notification::make()
+                    ->title('Import Gagal: ' . $e->getMessage())
+                    ->danger()
+                    ->send();
+            }
+        } else {
+            Notification::make()
+                ->title('File tidak valid')
+                ->danger()
+                ->send();
+        }
+    }
+}

--- a/app/Filament/Resources/FamilyResource/Pages/ListFamilies.php
+++ b/app/Filament/Resources/FamilyResource/Pages/ListFamilies.php
@@ -10,6 +10,7 @@ use Filament\Forms\Components\Html;
 use Maatwebsite\Excel\Facades\Excel;
 use Filament\Notifications\Notification;
 use Filament\Forms\Components\FileUpload;
+use App\Filament\Pages\ImportFamilies;
 use Filament\Resources\Pages\ListRecords;
 use App\Filament\Resources\FamilyResource;
 use Filament\Forms\Components\Placeholder;
@@ -26,39 +27,8 @@ class ListFamilies extends ListRecords
             Actions\Action::make('Import Excel')
                 ->label('Import Excel')
                 ->icon('heroicon-o-arrow-up-tray')
-                ->form([
-                    FileUpload::make('file')
-                        ->label('File Excel')
-                        ->hintActions([
-                            Action::make('Download Template')
-                                ->label('Download Template')
-                                ->url(route('families.template'))
-                        ])
-                        ->helperText('Pastikan file yang diunggah sesuai dengan format template yang telah disediakan.')
-                        ->required(),
-                ])
-                ->action(function (array $data) {
-                    $file = $data['file'];
-                    if ($file instanceof UploadedFile) {
-                        try {
-                            Excel::import(new FamilyImport, $file);
-                            Notification::make()
-                                ->title('Import Berhasil')
-                                ->success()
-                                ->send();
-                        } catch (\Exception $e) {
-                            Notification::make()
-                                ->title('Import Gagal: ' . $e->getMessage())
-                                ->danger()
-                                ->send();
-                        }
-                    } else {
-                        Notification::make()
-                            ->title('File tidak valid')
-                            ->danger()
-                            ->send();
-                    }
-                }),
+                ->url(ImportFamilies::getUrl())
+                ->color('primary'),
             Actions\Action::make('Export Excel')
                 ->label('Export Excel')
                 ->icon('heroicon-o-arrow-down-tray')

--- a/app/Imports/FamilyImport.php
+++ b/app/Imports/FamilyImport.php
@@ -23,19 +23,23 @@ class FamilySheetImport implements ToModel, WithHeadingRow
 {
     public function model(array $row)
     {
-        return new Family([
-            'kk_number' => $row['kk_number'],
-            'head_of_family' => $row['head_of_family'],
-            'wife_name' => $row['wife_name'] ?? null,
-            'house_block' => $row['house_block'],
-            'phone_1' => $row['phone_1'] ?? null,
-            'phone_2' => $row['phone_2'] ?? null,
-            'house_status' => $row['house_status'] ?? 'owner',
-            'status' => $row['status'] ?? 'active',
-            'family_members_count' => $row['family_members_count'] ?? 1,
-            'license_plate_1' => $row['license_plate_1'] ?? null,
-            'license_plate_2' => $row['license_plate_2'] ?? null,
-        ]);
+        return Family::updateOrCreate(
+            [
+                'kk_number' => $row['kk_number'],
+            ],
+            [
+                'head_of_family' => $row['head_of_family'],
+                'wife_name' => $row['wife_name'] ?? null,
+                'house_block' => $row['house_block'],
+                'phone_1' => $row['phone_1'] ?? null,
+                'phone_2' => $row['phone_2'] ?? null,
+                'house_status' => $row['house_status'] ?? 'owner',
+                'status' => $row['status'] ?? 'active',
+                'family_members_count' => $row['family_members_count'] ?? 1,
+                'license_plate_1' => $row['license_plate_1'] ?? null,
+                'license_plate_2' => $row['license_plate_2'] ?? null,
+            ]
+        );
     }
 }
 

--- a/resources/views/filament/pages/import-families.blade.php
+++ b/resources/views/filament/pages/import-families.blade.php
@@ -1,0 +1,15 @@
+<x-filament-panels::page>
+    <div class="space-y-4">
+        <div>
+            <a href="{{ route('families.template') }}" class="text-sm text-primary-600 hover:underline">
+                Unduh Template Import
+            </a>
+        </div>
+        <x-filament-panels::form wire:submit="import">
+            {{ $this->form }}
+            <x-filament::button type="submit" class="mt-4">
+                Import
+            </x-filament::button>
+        </x-filament-panels::form>
+    </div>
+</x-filament-panels::page>


### PR DESCRIPTION
## Summary
- implement `ImportFamilies` Filament page for uploading Excel templates
- link the new page from the family list header action
- add template download link in the page view
- update `FamilyImport` to update existing families on import

## Testing
- `php -l app/Filament/Pages/ImportFamilies.php`
- `php -l resources/views/filament/pages/import-families.blade.php`
- `php -l app/Filament/Resources/FamilyResource/Pages/ListFamilies.php`
- `php -l app/Imports/FamilyImport.php`
- `apt-get update`
- `apt-get install -y php-cli`

------
https://chatgpt.com/codex/tasks/task_b_6859f5e38d50833385393cb73b3b1181